### PR TITLE
Update MaxMessageLength behavior

### DIFF
--- a/wire/conn.go
+++ b/wire/conn.go
@@ -3,9 +3,9 @@ package wire
 import "github.com/zach-klippenstein/goadb/internal/errors"
 
 const (
-	// The official implementation of adb imposes an undocumented 255-byte limit
-	// on messages.
-	MaxMessageLength = 1024 * 1024
+	// The official implementation of adb imposes an undocumented 1-megabyte limit
+	// on payload size.
+	MaxPayloadSize = 1024 * 1024
 )
 
 /*

--- a/wire/conn.go
+++ b/wire/conn.go
@@ -5,7 +5,7 @@ import "github.com/zach-klippenstein/goadb/internal/errors"
 const (
 	// The official implementation of adb imposes an undocumented 255-byte limit
 	// on messages.
-	MaxMessageLength = 255
+	MaxMessageLength = 1024 * 1024
 )
 
 /*

--- a/wire/scanner.go
+++ b/wire/scanner.go
@@ -163,11 +163,6 @@ func readHexLength(r io.Reader) (int, error) {
 		return 0, errors.WrapErrorf(err, errors.NetworkError, "could not parse hex length %v", lengthHex)
 	}
 
-	// Clip the length to 255, as per the Google implementation.
-	if length > MaxMessageLength {
-		length = MaxMessageLength
-	}
-
 	return int(length), nil
 }
 

--- a/wire/scanner.go
+++ b/wire/scanner.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zach-klippenstein/goadb/internal/errors"
 )
 
-// TODO(zach): All EOF errors returned from networoking calls should use ConnectionResetError.
+// TODO(zach): All EOF errors returned from networking calls should use ConnectionResetError.
 
 // StatusCodes are returned by the server. If the code indicates failure, the
 // next message will be the error.

--- a/wire/sender.go
+++ b/wire/sender.go
@@ -29,7 +29,7 @@ func SendMessageString(s Sender, msg string) error {
 }
 
 func (s *realSender) SendMessage(msg []byte) error {
-	if len(msg) > MaxMessageLength {
+	if len(msg) > MaxMessageLength - 4 {
 		return errors.AssertionErrorf("message length exceeds maximum: %d", len(msg))
 	}
 

--- a/wire/sender.go
+++ b/wire/sender.go
@@ -29,7 +29,7 @@ func SendMessageString(s Sender, msg string) error {
 }
 
 func (s *realSender) SendMessage(msg []byte) error {
-	if len(msg) > MaxMessageLength - 4 {
+	if len(msg) > MaxPayloadSize- 4 {
 		return errors.AssertionErrorf("message length exceeds maximum: %d", len(msg))
 	}
 


### PR DESCRIPTION
This PR intends to update `goadb`'s behaviors regarding to message length. So that:

- Accept all message lengths returned from adb server
- Update `MaxMessageLength` and length-checking logics to reflect current adb's [implementation](https://cs.android.com/android/platform/superproject/+/master:packages/modules/adb/adb_io.cpp;drc=master;bpv=0;bpt=0;l=37)

This fixed #31, and (hopefully) #26 #29.

Please take a look @zach-klippenstein. Thanks!


