### PR TITLE
close event channel on shutdown

### DIFF
--- a/device_watcher.go
+++ b/device_watcher.go
@@ -83,7 +83,7 @@ func (w *DeviceWatcher) Err() error {
 // Shutdown stops the watcher from listening for events and closes the channel returned
 // from C.
 func (w *DeviceWatcher) Shutdown() {
-	// TODO(z): Implement.
+	close(w.eventChan)
 }
 
 func (w *deviceWatcherImpl) reportErr(err error) {


### PR DESCRIPTION
this will help jumping out of the for loop:
`for event := range watcher.C()`